### PR TITLE
feat: make Task execute timeout configurable via connection "task_timeout" (default 10s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,27 @@ Extending the SqlServer driver for Hyperf ORM through AOP and simulating corouti
 ```sh
 composer require chance-fyi/hyperf-database-sqlserver
 ```
+
+## Configuration
+
+Configure a SQL Server connection in `config/autoload/databases.php` as usual.
+Every query is dispatched to a task worker (to simulate coroutines over the
+blocking PDO/ODBC driver), and that task has an execute timeout.
+
+### Task timeout
+
+By default the task execute timeout is **10 seconds** (the Hyperf Task default).
+A heavy query that legitimately runs longer than 10s would otherwise fail with
+`Task [N] execute timeout`. Raise it per connection with the `task_timeout`
+option (in seconds):
+
+```php
+// config/autoload/databases.php
+return [
+    'sqlsrv' => [
+        'driver'       => 'sqlsrv',
+        // host / database / username / password / ...
+        'task_timeout' => 60, // optional, seconds, default 10
+    ],
+];
+```

--- a/src/SqlServerConnection.php
+++ b/src/SqlServerConnection.php
@@ -15,6 +15,8 @@ use Hyperf\Database\Connection;
 use Hyperf\Database\Query\Processors\Processor;
 use Hyperf\Database\Schema\Builder;
 use Hyperf\Support\Filesystem\Filesystem;
+use Hyperf\Task\Task as TaskMessage;
+use Hyperf\Task\TaskExecutor;
 use RuntimeException;
 use Throwable;
 
@@ -94,9 +96,7 @@ class SqlServerConnection extends Connection
     public function select(string $query, array $bindings = [], bool $useReadPdo = true): array
     {
         if (!$this->isTaskEnvironment) {
-            $client = ApplicationContext::getContainer()->get(SqlServerTask::class);
-
-            return $client->select((string) $this->getConfig('name'), $query, $bindings, $useReadPdo);
+            return $this->runInTaskWorker(__FUNCTION__, [(string) $this->getConfig('name'), $query, $bindings, $useReadPdo]);
         }
 
         return parent::select($query, $bindings, $useReadPdo);
@@ -105,9 +105,7 @@ class SqlServerConnection extends Connection
     public function statement(string $query, array $bindings = []): bool
     {
         if (!$this->isTaskEnvironment) {
-            $client = ApplicationContext::getContainer()->get(SqlServerTask::class);
-
-            return $client->statement((string) $this->getConfig('name'), $query, $bindings);
+            return $this->runInTaskWorker(__FUNCTION__, [(string) $this->getConfig('name'), $query, $bindings]);
         }
 
         return parent::statement($query, $bindings);
@@ -116,9 +114,7 @@ class SqlServerConnection extends Connection
     public function affectingStatement(string $query, array $bindings = []): int
     {
         if (!$this->isTaskEnvironment) {
-            $client = ApplicationContext::getContainer()->get(SqlServerTask::class);
-
-            return $client->affectingStatement((string) $this->getConfig('name'), $query, $bindings);
+            return $this->runInTaskWorker(__FUNCTION__, [(string) $this->getConfig('name'), $query, $bindings]);
         }
 
         return parent::affectingStatement($query, $bindings);
@@ -127,12 +123,26 @@ class SqlServerConnection extends Connection
     public function unprepared(string $query): bool
     {
         if (!$this->isTaskEnvironment) {
-            $client = ApplicationContext::getContainer()->get(SqlServerTask::class);
-
-            return $client->unprepared((string) $this->getConfig('name'), $query);
+            return $this->runInTaskWorker(__FUNCTION__, [(string) $this->getConfig('name'), $query]);
         }
 
         return parent::unprepared($query);
+    }
+
+    /**
+     * Dispatch a SqlServerTask method to a task worker.
+     *
+     * The Task execute timeout is configurable per connection through the
+     * `task_timeout` option (in seconds) and defaults to 10 to keep the
+     * previous behaviour. Raise it for heavy queries that legitimately take
+     * longer than 10s, which would otherwise fail with "Task [N] execute timeout".
+     */
+    protected function runInTaskWorker(string $method, array $arguments): mixed
+    {
+        $executor = ApplicationContext::getContainer()->get(TaskExecutor::class);
+        $timeout = (float) ($this->getConfig('task_timeout') ?? 10);
+
+        return $executor->execute(new TaskMessage([SqlServerTask::class, $method], $arguments), $timeout);
     }
 
     /**

--- a/src/Task/SqlServerTask.php
+++ b/src/Task/SqlServerTask.php
@@ -4,11 +4,9 @@ namespace Chance\Hyperf\Database\Sqlsrv\Task;
 
 use Chance\Hyperf\Database\Sqlsrv\SqlServerConnection;
 use Hyperf\DbConnection\Db;
-use Hyperf\Task\Annotation\Task;
 
 class SqlServerTask
 {
-    #[Task]
     public function select(string $connection, string $query, array $bindings = [], bool $useReadPdo = true): array
     {
         /** @var SqlServerConnection $conn */
@@ -17,7 +15,6 @@ class SqlServerTask
         return $conn->setIsTaskEnvironment()->select($query, $bindings, $useReadPdo);
     }
 
-    #[Task]
     public function statement(string $connection, string $query, array $bindings = []): bool
     {
         /** @var SqlServerConnection $conn */
@@ -26,7 +23,6 @@ class SqlServerTask
         return $conn->setIsTaskEnvironment()->statement($query, $bindings);
     }
 
-    #[Task]
     public function affectingStatement(string $connection, string $query, array $bindings = []): int
     {
         /** @var SqlServerConnection $conn */
@@ -35,7 +31,6 @@ class SqlServerTask
         return $conn->setIsTaskEnvironment()->affectingStatement($query, $bindings);
     }
 
-    #[Task]
     public function unprepared(string $connection, string $query): bool
     {
         /** @var SqlServerConnection $conn */


### PR DESCRIPTION
## Problem

All SQL Server queries are executed inside a Hyperf Task (to simulate coroutines over the blocking PDO/ODBC driver). `SqlServerTask`'s methods use a bare `#[Task]`, so the task execute timeout is the Hyperf default of **10 seconds**, hardcoded with no way to change it.

A query that legitimately runs longer than 10s fails with:

```
[ERROR] Task [N] execute timeout.
```

and its result is lost. We hit this in production on a heavy multi-table report query that intermittently crosses 10s.

## Change

Make the task execute timeout configurable per connection via a `task_timeout` option (in seconds), defaulting to `10` to keep current behaviour.

- `SqlServerConnection` now dispatches the task through `TaskExecutor` with the configured timeout instead of relying on the static `#[Task]` annotation.
- The `#[Task]` attribute on `SqlServerTask` is removed accordingly — dispatch is now explicit; execution inside the task worker is unchanged.
- Fully backward compatible: without `task_timeout` the timeout stays 10s, so existing users need no change.

## Usage

```php
// config/autoload/databases.php
'sqlsrv' => [
    'driver'       => 'sqlsrv',
    // host / database / username / password / ...
    'task_timeout' => 60, // optional, seconds, default 10
],
```
