### PR TITLE
fix: run query inline when no task worker is available (regression from #2, breaks CLI/console)

### DIFF
--- a/src/SqlServerConnection.php
+++ b/src/SqlServerConnection.php
@@ -140,6 +140,12 @@ class SqlServerConnection extends Connection
     protected function runInTaskWorker(string $method, array $arguments): mixed
     {
         $executor = ApplicationContext::getContainer()->get(TaskExecutor::class);
+        if ($executor->isTaskEnvironment()) {
+            // No task worker to offload to (CLI/command context, or already inside
+            // a task worker): run the query inline instead of dispatching.
+            return ApplicationContext::getContainer()->get(SqlServerTask::class)->{$method}(...$arguments);
+        }
+
         $timeout = (float) ($this->getConfig('task_timeout') ?? 10);
 
         return $executor->execute(new TaskMessage([SqlServerTask::class, $method], $arguments), $timeout);


### PR DESCRIPTION
## Problem

#2 (released in v3.0.2) made the task timeout configurable, but to do so it removed the `#[Task]` attribute from `SqlServerTask` and replaced the dispatch with a direct `TaskExecutor->execute()` call.

The original `#[Task]` aspect (`Hyperf\Task\Aspect\TaskAspect`) guarded the dispatch:

```php
if ($executor->isTaskEnvironment()) {
    return $proceedingJoinPoint->process(); // run inline, no dispatch
}
```

`runInTaskWorker()` dropped that guard, so it now always calls `TaskExecutor->execute()`. When there is no Swoole server running — e.g. a console command via `bin/hyperf.php ...`, where `TaskExecutor::$server` is null and `isTaskEnvironment()` is its default `true` — `execute()` throws:

```
The server does not support task.
```

So any SQL Server query issued from a command / CLI context (which worked fine before v3.0.2) now fails. Queries from the HTTP/cron server are unaffected because a task worker exists there.

## Fix

Restore the inline-execution path: when `TaskExecutor::isTaskEnvironment()` is true (no server to offload to — CLI/console — or we are already inside a task worker), run the `SqlServerTask` method inline instead of dispatching; otherwise dispatch with the configured `task_timeout` as before.

This mirrors the original `TaskAspect` behaviour while keeping the configurable timeout from #2. Backward compatible.
